### PR TITLE
G4Gamma -> G4OpticalPhoton

### DIFF
--- a/tracking.cc
+++ b/tracking.cc
@@ -1,6 +1,5 @@
 #include "tracking.hh"
 
-
 MyTrackingAction::MyTrackingAction(MyEventAction *eventAction,MyG4Args *MainArgs)
 {
     PassArgs=MainArgs;
@@ -30,7 +29,7 @@ void MyTrackingAction::PostUserTrackingAction(const G4Track*)
          size_t nmbSecTracks = (*secTracks).size();       
 
          for (size_t i = 0; i < nmbSecTracks; i++) { 
-            if ((*secTracks)[i]->GetDefinition() == G4Gamma::Definition()) {
+            if ((*secTracks)[i]->GetDefinition() == G4OpticalPhoton::Definition()) {
                 trPhCount++;
                 fEventAction->AddPh(1.);
             }

--- a/tracking.hh
+++ b/tracking.hh
@@ -4,12 +4,10 @@
 #include "G4UserEventAction.hh"
 #include "G4Track.hh"
 #include "G4AnalysisManager.hh"
-#include "G4Electron.hh"
-#include "G4Gamma.hh"
+#include "G4OpticalPhoton.hh"
 #include "G4UserTrackingAction.hh"
 #include "G4TrackingManager.hh"
 #include "event.hh"
-//#include "groot.hh"
 #include "G4Args.hh"
 #include "run.hh"
 
@@ -29,36 +27,3 @@ private :
 };
 
 #endif
-
-/*
-#include "UserTrackingAction.hh"
-#include "G4TrackingManager.hh"
-#include "G4Electron.hh"
-
-
-UserTrackingAction::UserTrackingAction() :
-    counter(0) {
-
-}
-
-
-void UserTrackingAction::PostUserTrackingAction(const G4Track*) {
-
-  // The user tracking action class holds the pointer to the tracking manager:
-  // fpTrackingManager
-
-  // From the tracking manager we can retrieve the secondary track vector,
-  // which is a container class for tracks:
-  G4TrackVector* secTracks = fpTrackingManager -> GimmeSecondaries();
-
-  // You can use the secTracks vector to retrieve the number of secondary 
-  // electrons
-  if(secTracks) { 
-     size_t nmbSecTracks = (*secTracks).size();       
-
-     for(size_t i = 0; i < nmbSecTracks; i++) { 
-        if((*secTracks)[i] -> GetDefinition() == G4Electron::Definition()) 
-              counter++;
-     }
-  }
-}*/


### PR DESCRIPTION
This commit updates the tracking code to look for secondary optical
photons instead of gammas.

I think this was just a typo, or was the code supposed to be looking for secondary gammas?