### PR TITLE
G4sipm integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,9 @@
 	path = NSGAII/PyNSGA/NSGA-II
 	url = https://github.com/grealesguti/NSGA-II.git
 	branch = greales/dev
+[submodule "src_G4/externals/g4sipm/g4sipm"]
+	path = src_G4/externals/g4sipm/g4sipm
+	url = https://github.com/ntim/g4sipm.git
+[submodule "src_G4/g4sipm"]
+	path = src_G4/g4sipm
+	url = https://github.com/ntim/g4sipm.git

--- a/Makefile.localgmsh
+++ b/Makefile.localgmsh
@@ -2,9 +2,10 @@
  CC=gcc
  CXX=g++
  LD=g++
- CXXFLAGS=-fdiagnostics-color -O2 -g $(shell geant4-config --cflags) -O2  -L/home/gmsh/lib -lgmsh
- LDLIBS=-Wl,--copy-dt-needed-entries -fdiagnostics-color -lm $(shell geant4-config --libs)  -L/home/gmsh/lib -lgmsh
-
+ CXXFLAGS=-fdiagnostics-color -O2 -g $(shell geant4-config --cflags) -O2  -L/home/Software/gmsh-install/lib64 -lgmsh -I/home/Software/gmsh-install/include -I/home/surf/surf/g4sipm/source/g4sipm/include -I/home/surf/surf/g4sipm/source/g4sipm/externals/jansson/src -I/home/surf/surf/g4sipm/source/g4sipm//externals/gtest/include
+ LDFLAGS=-L/home/Software/gmsh-install/lib64 \
+	 -L/home/surf/surf/g4sipm/build/g4sipm
+ LDLIBS=-Wl,--copy-dt-needed-entries -fdiagnostics-color -lm $(shell geant4-config --libs)  -lgmsh -lg4sipm
 PWD=$(shell pwd)
 
 PREFIX?=$(HOME)/local

--- a/README.txt
+++ b/README.txt
@@ -44,6 +44,17 @@ Now introduce the path to the singularity file within your submission file
 To run it locally remember to install singularity:
 https://www.linuxwave.info/2022/02/installing-singularity-in-ubuntu-2004.html
 
+###Installing G4Sipm
+To enable to the realistic Sipm simulation using the G4Sipm package. Install it through source:
+https://github.com/ntim/g4sipm
+
+Since the simulation is running on Geant4 v11. Implement the changes stated in this merge request for the G4Sipm package before building to incorporate Geant4 V11 compatibility:
+https://github.com/ntim/g4sipm/pull/5/commits/53d953ee2427309cfa4d6b94d60f09a28ba1fa20
+
+Update the Dynamic Linker Path to include the directory containing libg4sipm.so (alternatively you can use LD_LIBRARY_PATH)
+
+Run the simulation normally with the added command `-G4Sipm`.
+
 ### Running in TierII
 
 Login into TierII: `username@login-1.hep.caltech.edu`
@@ -116,6 +127,8 @@ The commands work as follow `-command argument`, in `[]` we set the number of op
 -TileV0 : changes configuration from bar to tile. (TODO: right now the design is assymmetrical, the triangulation needs to be changed in Gmsh)
 -ForceBottomLine: To always be used with -TileV0. Forces a given flat bottom surface.
 -SZloc [0-1] : changes the SiPM location along Z at the bottom of the tile as a percentage of LYSO_L.
+
+-G4Sipm : changes the G4VSensitiveDetectors to the ones implemented through G4Sipm package. This realistic simulation of the Sipm allows for digitized results and voltage readouts similar to the output of a real Sipm. The Sipm Can be custom defined to fit the simulation target.
 
 ## How to start the graphical interface
 

--- a/sim.cc
+++ b/sim.cc
@@ -21,8 +21,8 @@ VISUALIZATION: Everythin in between * Vis -> Visualizer* lines of with it at the
 /////////////////////////////////// PROGRAM START ///////////////////////////////////
 
 //#include "G4RunManager.hh" /* Run */
-#include "src_G4/G4simTierII.hh"
-//#include "src_G4/G4sim.hh"
+//#include "src_G4/G4simTierII.hh"
+#include "src_G4/G4sim.hh"
 #include "src_G4/util.hh"
 #include <iostream>
 #include <string>
@@ -53,11 +53,11 @@ int main(int argc, char** argv) /* argc, argv are the argument passed to the sim
     radinit[0]=1;
     radinit[1]=0.5;
     //G4double radinit[2]={1,2};
-    G4simulationNOVIS *sim = new G4simulationNOVIS(argc, argv);
+   // G4simulationNOVIS *sim = new G4simulationNOVIS(argc, argv);
 
 
     //G4simulationNOVIS *sim1 = new G4simulationNOVIS(runManager,argc, argv, Onode, Znode, radinit);
-    //G4simulation *sim = new G4simulation(argc, argv);
+    G4simulation *sim = new G4simulation(argc, argv);
     // Example on how to pass always the same arguments
 /*
     G4int argc1=3;

--- a/sim.cc
+++ b/sim.cc
@@ -21,8 +21,8 @@ VISUALIZATION: Everythin in between * Vis -> Visualizer* lines of with it at the
 /////////////////////////////////// PROGRAM START ///////////////////////////////////
 
 //#include "G4RunManager.hh" /* Run */
-//#include "src_G4/G4simTierII.hh"
-#include "src_G4/G4sim.hh"
+#include "src_G4/G4simTierII.hh"
+//#include "src_G4/G4sim.hh"
 #include "src_G4/util.hh"
 #include <iostream>
 #include <string>
@@ -53,11 +53,11 @@ int main(int argc, char** argv) /* argc, argv are the argument passed to the sim
     radinit[0]=1;
     radinit[1]=0.5;
     //G4double radinit[2]={1,2};
-   // G4simulationNOVIS *sim = new G4simulationNOVIS(argc, argv);
+    G4simulationNOVIS *sim = new G4simulationNOVIS(argc, argv);
 
 
     //G4simulationNOVIS *sim1 = new G4simulationNOVIS(runManager,argc, argv, Onode, Znode, radinit);
-    G4simulation *sim = new G4simulation(argc, argv);
+   // G4simulation *sim = new G4simulation(argc, argv);
     // Example on how to pass always the same arguments
 /*
     G4int argc1=3;

--- a/src_G4/G4Args.cc
+++ b/src_G4/G4Args.cc
@@ -441,8 +441,8 @@ G4cout<< " * imax: "<< imax<< " jmax: "<< jmax <<G4endl;
                     for (int i = 0; i < imax; i++){
                         for (int j = 0; j < jmax; j++){
                             index = i*jmax+j;
-                            nGunPosX[index]=(Geom_LYSO[0]-0.01)/imax*(i);
-                            nGunPosY[index]=(Geom_LYSO[2]-0.01)/jmax*(j);
+                            nGunPosX[index]=(Geom_LYSO[0]-0.01)/imax*(i)+0.01;
+                            nGunPosY[index]=(Geom_LYSO[2]-0.01)/jmax*(j)+0.01;
                         G4cout<< " * Gun Pos "<< index <<" , XPos  : " << nGunPosX[index]<<" , YPos  : " << nGunPosY[index]<<G4endl;    
                         }
                     }     
@@ -477,7 +477,10 @@ G4cout<< " * imax: "<< imax<< " jmax: "<< jmax <<G4endl;
                         G4cout<< " ### WARNING: -Ypos with no Znode input" <<G4endl;     
                     }
                         
-                }
+                }else if(strcmp(mainargv[j],"-G4Sipm")==0){   
+                    RealSipm=1;
+                    G4cout<< " ### Realistic Sipm "<<G4endl; 
+		}
         }
         
     if (Ystr==1 && NoYSym==0){

--- a/src_G4/G4Args.hh
+++ b/src_G4/G4Args.hh
@@ -194,7 +194,10 @@ public:
 
     G4double GetGeomIndv(G4int runid) const {return RndGenIndv[runid];}  
     G4double GetSZloc(){return SZ_loc;}
-	bool IsVolumeInList(const G4LogicalVolume* volume);
+    G4int GetG4SipmState() const {return RealSipm;}
+
+
+    bool IsVolumeInList(const G4LogicalVolume* volume);
     void InitfScoringVolumeVec(std::vector<G4LogicalVolume*> fScoringVolumeVecinit) {fScoringVolumeVec=fScoringVolumeVecinit;}  
     void PushfScoringVolumeVec(G4LogicalVolume *LYSOTet_Logic) {fScoringVolumeVec.push_back(LYSOTet_Logic);}  
 
@@ -301,6 +304,7 @@ private:
     G4double IQRLO = 0;
     G4double IQRLD = 0;
     G4double IQRLSt = 0;
+    G4int RealSipm = 0;
 
 };    
 

--- a/src_G4/G4Args.hh
+++ b/src_G4/G4Args.hh
@@ -204,7 +204,7 @@ private:
     // Default values modifiable by arguments and able to be returned!!!
     G4int Oin=0; 
     G4int nrep=0; 
-    G4int MainTrees[6]={0, 1, 0, 0, 1, 1};// Options to write(1)/orNot(0) the different output trees {Arrivals,Detected,Stepping,Tracking,EndOfEvent}
+    G4int MainTrees[7]={0, 1, 0, 0, 1, 1, 1};// Options to write(1)/orNot(0) the different output trees {Arrivals,Detected,Stepping,Tracking,EndOfEvent,DigiCollection}
     G4double LYSOProps[4]={40000.,0.,60.,39.1};//Options to modify default LYSO properties {Yield,ScaleResolution,RiseTime,DecayTime}
     G4int RndGen[3]={1,1,1};             // Options regarding the random generator {Init,Particle,Geometry}
     G4double Geom_LYSO[3]={3./2.,3./2.,57./2.};//Options to modify default Geom properties {...}

--- a/src_G4/construction.cc
+++ b/src_G4/construction.cc
@@ -13,6 +13,7 @@ MyDetectorConstruction::MyDetectorConstruction(MyG4Args *MainArgs)
     ArgsPass=MainArgs;       
 
 // Create SiPM and housing.
+// TODO: create command line arguments for selecting model and housing (if necessary)
     G4SipmModel* model = createSipmModel("generic");
     housing = createHousing("default", new G4Sipm(model));
 
@@ -323,6 +324,8 @@ G4VPhysicalVolume *MyDetectorConstruction::Construct()
 	solidWorld = new G4Box("solidWorld", xWorld, yWorld, zWorld);
     logicWorld = new G4LogicalVolume(solidWorld, worldMat, "logicWorld");
     physWorld = new G4PVPlacement(0,G4ThreeVector(0.,0.,0.),logicWorld,"physWorld",0,false,0,true);
+
+    G4int RealSipm = ArgsPass->GetG4SipmState();
 	
 ////////////////////
 // SOLID VOLUMES  // G4Box("var", width*m, lengtg*m, thickness*m);
@@ -746,7 +749,13 @@ physResin2 = new G4PVPlacement(rM,G4ThreeVector(XposTol2*mm,YposTol2*mm+RESIN_Y*
 //physResin2 = new G4PVPlacement(rM,G4ThreeVector(XposTol2*mm,YposTol2*mm+(RESIN_H-0.5*mm-LYSO_thick),-1*(+LYSO_L*mm+GLUE_L*mm*2+RESIN_L*mm+DET_L)),logicResin_Sub,"physResin2",logicWorld,false,0,true); 
     //physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol*mm,YposTol*mm,+1*(+LYSO_L*mm+RESIN_L*mm*2+2*GLUE_L*mm+DET_L)),logicDetector,"physDetector",logicWorld,false,0,true); 
 
-    physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol2*mm,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)),logicDetector,"physDetector",logicResin_Sub,false,1,true); 
+	if (RealSipm) {
+     		housing->setPosition(G4ThreeVector(XposTol2*mm,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)));
+        	// Build SiPM.
+     		housing->buildAndPlace(physResin1);
+	}else{
+    		physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol2*mm,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)),logicDetector,"physDetector",logicResin_Sub,false,1,true); 
+	}
 
 physFR41 = new G4PVPlacement(0     ,G4ThreeVector(XposTol*mm,YposTol*mm+RESIN_Y,+1*(+LYSO_L*mm+GLUE_L*mm*2+2*(RESIN_L*mm+DET_L)+FR4_L)),logicFR4,"physResin1",logicWorld,false,0,true); 
 physFR42 = new G4PVPlacement(rM,G4ThreeVector(XposTol2*mm,YposTol2*mm+RESIN_Y,-1*(+LYSO_L*mm+GLUE_L*mm*2+2*(RESIN_L*mm+DET_L)+FR4_L)),logicFR4,"physResin2",logicWorld,false,0,true);
@@ -758,8 +767,14 @@ physFR42 = new G4PVPlacement(rM,G4ThreeVector(XposTol2*mm,YposTol2*mm+RESIN_Y,-1
     physLYSO = new G4PVPlacement(0,G4ThreeVector(0.,0.,-LYSO_L/2.*mm),logicLYSO,"physLYSO",logicWorld,false,0,true);       
 
     physGlue1 = new G4PVPlacement   (0,G4ThreeVector(XposTol*mm,YposTol*mm+(RESIN_H-0.5*mm-DET_T),+1*(+LYSO_L*mm+GLUE_L*mm)),logicGlue,"physGlue1",logicWorld,false,0,true); 
-    physResin1 = new G4PVPlacement  (0,G4ThreeVector(XposTol*mm,YposTol*mm+(RESIN_H-0.5*mm-DET_T),+1*(+LYSO_L*mm+GLUE_L*mm*2+RESIN_L*mm+DET_L)),logicResin_Sub,"physResin1",logicWorld,false,0,true); 
-    physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol*mm,YposTol*mm,+1*(+LYSO_L*mm+RESIN_L*mm*2+2*GLUE_L*mm+DET_L)),logicDetector,"physDetector",logicWorld,false,0,true); 
+    physResin1 = new G4PVPlacement  (0,G4ThreeVector(XposTol*mm,YposTol*mm+(RESIN_H-0.5*mm-DET_T),+1*(+LYSO_L*mm+GLUE_L*mm*2+RESIN_L*mm+DET_L)),logicResin_Sub,"physResin1",logicWorld,false,0,true);
+	if (RealSipm) {
+     		housing->setPosition(G4ThreeVector(XposTol*mm,YposTol*mm,+1*(+LYSO_L*mm+RESIN_L*mm*2+2*GLUE_L*mm+DET_L)));
+        	// Build SiPM.
+     		housing->buildAndPlace(physWorld);
+	}else{
+    		physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol*mm,YposTol*mm,+1*(+LYSO_L*mm+RESIN_L*mm*2+2*GLUE_L*mm+DET_L)),logicDetector,"physDetector",logicWorld,false,0,true); 
+	}
     physFR41 = new G4PVPlacement    (0,G4ThreeVector(XposTol*mm,YposTol*mm+(RESIN_H-0.5*mm-DET_T),+1*(+LYSO_L*mm+GLUE_L*mm*2+2*(RESIN_L*mm+DET_L)+FR4_L)),logicFR4,"physResin1",logicWorld,false,0,true); 
 //////////////
 // GEOM TYPE 3
@@ -775,12 +790,24 @@ physResin2 = new G4PVPlacement(rM,G4ThreeVector(XposTol2*mm,YposTol2*mm+(RESIN_H
             G4cout<< " ### GeomConfig Resin"<<G4endl;          
 
 for(int i = 0; i < nSiPM; i++){
-            G4cout<< " ### SiPM Positioning Left"<< i<<G4endl;          
-    physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol*mm-RESIN_W+DET_TX+0.194*(i+1)*mm+DET_TX*2*i,YposTol*mm,+1*(+LYSO_L*mm+RESIN_L*mm*2+2*GLUE_L*mm+DET_L)),logicDetector,"physDetector",logicWorld,false,i-1,true); 
+	G4cout<< " ### SiPM Positioning Left"<< i<<G4endl;          
+	if (RealSipm) {
+     		housing->setPosition(G4ThreeVector(XposTol*mm-RESIN_W+DET_TX+0.194*(i+1)*mm+DET_TX*2*i,YposTol*mm,+1*(+LYSO_L*mm+RESIN_L*mm*2+2*GLUE_L*mm+DET_L)));
+        	// Build SiPM.
+     		housing->buildAndPlace(physWorld);
+	}else{
+    		physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol*mm-RESIN_W+DET_TX+0.194*(i+1)*mm+DET_TX*2*i,YposTol*mm,+1*(+LYSO_L*mm+RESIN_L*mm*2+2*GLUE_L*mm+DET_L)),logicDetector,"physDetector",logicWorld,false,i-1,true); 
+	}
 }
 for(int i = 0; i < nSiPM; i++){   
-            G4cout<< " ### SiPM Positioning Right"<< i<<G4endl;          
-physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol2*mm-RESIN_W+DET_TX+0.194*(i+1)*mm+DET_TX*2*i,YposTol2*mm,-1*(+LYSO_L*mm+RESIN_L*mm*2+2*GLUE_L*mm+DET_L)),logicDetector,"physDetector",logicWorld,false,i+nSiPM-1,true); 
+	G4cout<< " ### SiPM Positioning Right"<< i<<G4endl;          
+	if (RealSipm) {
+     		housing->setPosition(G4ThreeVector(XposTol2*mm-RESIN_W+DET_TX+0.194*(i+1)*mm+DET_TX*2*i,YposTol2*mm,-1*(+LYSO_L*mm+RESIN_L*mm*2+2*GLUE_L*mm+DET_L)));
+        	// Build SiPM.
+     		housing->buildAndPlace(physWorld);
+	}else{
+		physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol2*mm-RESIN_W+DET_TX+0.194*(i+1)*mm+DET_TX*2*i,YposTol2*mm,-1*(+LYSO_L*mm+RESIN_L*mm*2+2*GLUE_L*mm+DET_L)),logicDetector,"physDetector",logicWorld,false,i+nSiPM-1,true); 
+	}
 }
 
 physFR41 = new G4PVPlacement(0     ,G4ThreeVector(XposTol*mm,YposTol*mm+(RESIN_H-0.5*mm-LYSO_thick),+1*(+LYSO_L*mm+GLUE_L*mm*2+2*(RESIN_L*mm+DET_L)+FR4_L)),logicFR4,"physResin1",logicWorld,false,0,true); 
@@ -798,6 +825,8 @@ for(int i = 0; i < nSiPM; i++){
 }
 physFR41 = new G4PVPlacement(0     ,G4ThreeVector(XposTol*mm,YposTol*mm+(RESIN_H-0.5*mm-LYSO_thick),+1*(+LYSO_L*mm+GLUE_L*mm*2+2*(RESIN_L*mm+DET_L)+FR4_L)),logicFR4,"physResin1",logicWorld,false,0,true); 
 physFR42 = new G4PVPlacement(rM,G4ThreeVector(XposTol*mm,YposTol*mm+(RESIN_H-0.5*mm-LYSO_thick),-1*(+LYSO_L*mm+GLUE_L*mm*2+2*(RESIN_L*mm+DET_L)+FR4_L)),logicFR4,"physResin2",logicWorld,false,0,true);
+//TODO: There is no sensitive detector for GeomConfig 4, so I didn't add an G4sipm for this one. Let me know if it is needed.
+
 
 }//////////////
 // GEOM TYPE 11
@@ -825,13 +854,14 @@ else if(GeomConfig == 11 ){
 		
 		physFR41 = new G4PVPlacement(rM0     ,G4ThreeVector(0,FYdispl,+1*(+ZLloc)),logicFR4,"physResin1",logicWorld,false,0,true); 
 		physFR42 = new G4PVPlacement(rM,G4ThreeVector(0,FYdispl,-1*(+ZLloc)),logicFR4,"physResin2",logicWorld,false,0,true);
+		if (RealSipm) {
+     			housing->setPosition(G4ThreeVector(XposTol2*mm,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)));
+        		// Build SiPM.
+     			housing->buildAndPlace(physResin1);
+		}else{
+			physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol2*mm,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)),logicDetector,"physDetector",logicResin_Sub,false,1,true); 
+		}
 
-     		housing->setPosition(G4ThreeVector(XposTol2*mm,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)));
-        	// Build SiPM.
-     		housing->buildAndPlace(physResin1);
-
-	//	physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol2*mm,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)),logicDetector,"physDetector",logicResin_Sub,false,1,true); 
-		
 			if (ArgsPass->GetReflSiPM()==1){
 				G4double GXdispl = 0; 
 				G4double GYdispl = -GLUE_L*2-0.1; 
@@ -863,7 +893,14 @@ else if(GeomConfig == 11 ){
 		physResin2 = new G4PVPlacement(rM,G4ThreeVector(XposTol2*mm,YposTol2*mm+RESIN_Y*mm,-1*(+LYSO_L*mm+GLUE_L*mm*2+RESIN_L*mm+DET_L)),logicResin_Sub,"physResin2",logicWorld,false,0,true); 		
 		physFR41 = new G4PVPlacement(0     ,G4ThreeVector(XposTol*mm,YposTol*mm+RESIN_Y,+1*(+LYSO_L*mm+GLUE_L*mm*2+2*(RESIN_L*mm+DET_L)+FR4_L)),logicFR4,"physResin1",logicWorld,false,0,true); 
 		physFR42 = new G4PVPlacement(rM,G4ThreeVector(XposTol2*mm,YposTol2*mm+RESIN_Y,-1*(+LYSO_L*mm+GLUE_L*mm*2+2*(RESIN_L*mm+DET_L)+FR4_L)),logicFR4,"physResin2",logicWorld,false,0,true);
-		physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol2*mm,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)),logicDetector,"physDetector",logicResin_Sub,false,1,true); 
+
+		if (RealSipm) {
+     			housing->setPosition(G4ThreeVector(XposTol2*mm,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)));
+        		// Build SiPM.
+     			housing->buildAndPlace(physResin1);
+		}else{
+			physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol2*mm,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)),logicDetector,"physDetector",logicResin_Sub,false,1,true); 
+		}
 
 			if (ArgsPass->GetReflSiPM()==1){
 				G4cout<< " ### GLUE REFL "<<ArgsPass->GetReflSiPM() <<G4endl;    
@@ -907,25 +944,39 @@ physResin2 = new G4PVPlacement(rM,G4ThreeVector(XposTol2*mm,YposTol2*mm+RESIN_Y*
 //physResin1 = new G4PVPlacement(0     ,G4ThreeVector(XposTol*mm,YposTol*mm+(RESIN_H-0.5*mm-LYSO_thick),+1*(+LYSO_L*mm+GLUE_L*mm*2+RESIN_L*mm+DET_L)),logicResin_Sub,"physResin1",logicWorld,false,0,true); 
 //physResin2 = new G4PVPlacement(rM,G4ThreeVector(XposTol2*mm,YposTol2*mm+(RESIN_H-0.5*mm-LYSO_thick),-1*(+LYSO_L*mm+GLUE_L*mm*2+RESIN_L*mm+DET_L)),logicResin_Sub,"physResin2",logicWorld,false,0,true); 
     //physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol*mm,YposTol*mm,+1*(+LYSO_L*mm+RESIN_L*mm*2+2*GLUE_L*mm+DET_L)),logicDetector,"physDetector",logicWorld,false,0,true); 
+
 	G4double* XposGC3 = new G4double[16];
 	G4double Xtrans=-8;
 	
 	for (int i = 0; i < 16; i += 1) {
 		XposGC3[i]=-LYSO_thick*2*7-0.2*7-0.1-LYSO_thick+(LYSO_thick*2+0.2)*i;
+		G4cout<<"GC3 pos" <<  XposGC3[i]<< G4endl;
+	}
+
+	for(int i = 0; i < nSiPM; i++){
+		G4cout<< " ### SiPM Positioning Left"<< i<<G4endl;          
+		if (RealSipm) {
+     			housing->setPosition(G4ThreeVector(XposTol2*mm+XposGC3[i]*mm,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)));
+        		// Build SiPM.
+     			housing->buildAndPlace(physResin1);
+		}else{
+			//physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol*mm-RESIN_W+DET_TX+0.194*(i+1)*mm+DET_TX*2*i,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)),logicResin_Sub,"physDetector",logicWorld,false,i-1,true); 
+    			physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol2*mm+XposGC3[i]*mm,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)),logicDetector,"physDetector",logicResin_Sub,false,i-1,true); 
 		}
-	for(int i = 0; i < nSiPM; i++){
-				G4cout<< " ### SiPM Positioning Left"<< i<<G4endl;          
-		//physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol*mm-RESIN_W+DET_TX+0.194*(i+1)*mm+DET_TX*2*i,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)),logicResin_Sub,"physDetector",logicWorld,false,i-1,true); 
-    physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol2*mm+XposGC3[i]*mm,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)),logicDetector,"physDetector",logicResin_Sub,false,i-1,true); 
-    	            G4cout<< " ### Phys Detector Volume 11"<<G4endl;  
+		G4cout<< " ### Phys Detector Volume 11"<<G4endl;
 	}
 	for(int i = 0; i < nSiPM; i++){
-				G4cout<< " ### SiPM Positioning Left"<< i<<G4endl;          
-		//physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol*mm-RESIN_W+DET_TX+0.194*(i+1)*mm+DET_TX*2*i,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)),logicResin_Sub,"physDetector",logicWorld,false,i-1,true); 
-    physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol2*mm+XposGC3[i]*mm,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)),logicDetector,"physDetector",logicResin_Sub2,false,100+i-1,true); 
-    	            G4cout<< " ### Phys Detector Volume 11"<<G4endl;  
-	}
-        
+		G4cout<< " ### SiPM Positioning Left"<< i<<G4endl;          
+		if (RealSipm) {
+     			housing->setPosition(G4ThreeVector(XposTol2*mm+XposGC3[i]*mm,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)));
+        		// Build SiPM.
+     			housing->buildAndPlace(physResin2);
+		}else{
+			//physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol*mm-RESIN_W+DET_TX+0.194*(i+1)*mm+DET_TX*2*i,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)),logicResin_Sub,"physDetector",logicWorld,false,i-1,true); 
+    			physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol2*mm+XposGC3[i]*mm,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)),logicDetector,"physDetector",logicResin_Sub2,false,100+i-1,true); 
+		}
+    	        G4cout<< " ### Phys Detector Volume 11"<<G4endl;  
+	}        
 
 physFR41 = new G4PVPlacement(0     ,G4ThreeVector(XposTol*mm,YposTol*mm+RESIN_Y,+1*(+LYSO_L*mm+GLUE_L*mm*2+2*(RESIN_L*mm+DET_L)+FR4_L)),logicFR4,"physResin1",logicWorld,false,0,true); 
 physFR42 = new G4PVPlacement(rM,G4ThreeVector(XposTol2*mm,YposTol2*mm+RESIN_Y,-1*(+LYSO_L*mm+GLUE_L*mm*2+2*(RESIN_L*mm+DET_L)+FR4_L)),logicFR4,"physResin2",logicWorld,false,0,true);

--- a/src_G4/construction.cc
+++ b/src_G4/construction.cc
@@ -1,10 +1,21 @@
 #include "construction.hh"
 #include "util.hh"
 #include "materials.hh"
+#include "G4Sipm.hh"
+#include "MaterialFactory.hh"
+#include "model/G4SipmModelFactory.hh"
+#include "housing/G4SipmHousing.hh"
+#include "housing/impl/HamamatsuCeramicHousing.hh"
+#include "housing/impl/HamamatsuSmdHousing.hh"
 
 MyDetectorConstruction::MyDetectorConstruction(MyG4Args *MainArgs)
 {// constructor
-    ArgsPass=MainArgs;              
+    ArgsPass=MainArgs;       
+
+// Create SiPM and housing.
+    G4SipmModel* model = createSipmModel("generic");
+    housing = createHousing("default", new G4Sipm(model));
+
         G4cout<< " ### Default Construction Values. " <<G4endl;         
     DefaultValues();
         G4cout<< " ### Default Messengers. " <<G4endl;         
@@ -20,7 +31,52 @@ MyDetectorConstruction::MyDetectorConstruction(MyG4Args *MainArgs)
 }
 
 MyDetectorConstruction::~MyDetectorConstruction()
-{}
+{
+    delete housing;
+}
+
+G4SipmModel* MyDetectorConstruction::createSipmModel(std::string name) const {
+        if (name == "generic") {
+                return G4SipmModelFactory::getInstance()->createGenericSipmModel();
+        }
+        if (name == "HamamatsuS1036211100") {
+                return G4SipmModelFactory::getInstance()->createHamamatsuS1036211100();
+        }
+        if (name == "HamamatsuS1036233100") {
+                return G4SipmModelFactory::getInstance()->createHamamatsuS1036233100();
+        }
+        if (name == "HamamatsuS10985100") {
+                return G4SipmModelFactory::getInstance()->createHamamatsuS10985100();
+        }
+        if (name == "HamamatsuS12651050") {
+                return G4SipmModelFactory::getInstance()->createHamamatsuS12651050();
+        }
+        if (name == "HamamatsuS1036233050") {
+                return G4SipmModelFactory::getInstance()->createHamamatsuS1036233050();
+        }
+        if (name == "HamamatsuS12573100C") {
+                return G4SipmModelFactory::getInstance()->createHamamatsuS12573100C();
+        }
+        if (name == "HamamatsuS12573100X") {
+                return G4SipmModelFactory::getInstance()->createHamamatsuS12573100X();
+        }
+        return G4SipmModelFactory::getInstance()->createConfigFileModel(name);
+}
+G4SipmHousing* MyDetectorConstruction::createHousing(std::string name, G4Sipm* sipm) const {
+        if (name == "ceramic") {
+                return new HamamatsuCeramicHousing(sipm);
+        }
+        if (name == "smd") {
+                return new HamamatsuSmdHousing(sipm);
+        }
+        if (name == "default") {
+                return new G4SipmHousing(sipm);
+        }
+        std::cout << "G4SipmDetectorConstruction::createHousingForName(name = \"" << name
+                        << "\"): housing type does not exist." << std::endl;
+        throw 1;
+}
+
 
 /* Function to define a single time the materials when parametrizing, materials
  * need to be defined in the class header! Definition of the function for the
@@ -769,7 +825,12 @@ else if(GeomConfig == 11 ){
 		
 		physFR41 = new G4PVPlacement(rM0     ,G4ThreeVector(0,FYdispl,+1*(+ZLloc)),logicFR4,"physResin1",logicWorld,false,0,true); 
 		physFR42 = new G4PVPlacement(rM,G4ThreeVector(0,FYdispl,-1*(+ZLloc)),logicFR4,"physResin2",logicWorld,false,0,true);
-		physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol2*mm,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)),logicDetector,"physDetector",logicResin_Sub,false,1,true); 
+
+     		housing->setPosition(G4ThreeVector(XposTol2*mm,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)));
+        	// Build SiPM.
+     		housing->buildAndPlace(physResin1);
+
+	//	physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol2*mm,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)),logicDetector,"physDetector",logicResin_Sub,false,1,true); 
 		
 			if (ArgsPass->GetReflSiPM()==1){
 				G4double GXdispl = 0; 
@@ -823,7 +884,7 @@ else if(GeomConfig == 11 ){
 				}
 		  }
 
-    physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol2*mm,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)),logicDetector,"physDetector",logicResin_Sub,false,1,true); 
+//    physDetector = new G4PVPlacement(0,G4ThreeVector(XposTol2*mm,YposTol2*mm+SiPM_Y,+1*(+RESIN_L*mm)),logicDetector,"physDetector",logicResin_Sub,false,1,true); 
     	            G4cout<< " ### Phys Detector Volume 11"<<G4endl;          
 
 

--- a/src_G4/construction.hh
+++ b/src_G4/construction.hh
@@ -27,6 +27,10 @@
 #include "detector.hh"
 #include "GmshLYSO.hh"
 
+/*G4Sipm Packages*/
+#include "G4Sipm.hh"
+#include "housing/G4SipmHousing.hh"
+
 class MyDetectorConstruction : public G4VUserDetectorConstruction
 {
 public:
@@ -50,8 +54,29 @@ public:
 
 
     virtual G4VPhysicalVolume *Construct(); // call to detector construction function
+    /**
+    * @return G4SipmModel - the SiPM model.
+    */
+    G4SipmModel* getSipmModel() const;
+    /**
+    * @return G4SipmHousing - the housing instance.
+    */
+    G4SipmHousing* getSipmHousing() const;
 private: // it is not accessed from outside
     
+    G4SipmHousing* housing;
+        /**
+         * @param name - the name of the model.
+         * @return G4SipmModel - the new instance.
+         */
+    G4SipmModel* createSipmModel(std::string name) const;
+        /**
+         * @param name - the name of the housing.
+         * @param sipm - the SiPM instance.
+         * @return G4SipmHousing - the new instance.
+         */
+    G4SipmHousing* createHousing(std::string name, G4Sipm* sipm) const;
+
     // Default Values
     G4int nCols, nRows, GeomConfig, ESRtrue;
     G4double LYSO_L, LYSO_YIELD,BC400_YIELD,BC400_RT1, LYSO_SCALERESOLUTION, Vovcon, LYSO_thick, perincr, DET_L;

--- a/src_G4/run.cc
+++ b/src_G4/run.cc
@@ -100,6 +100,16 @@ MyRunAction :: MyRunAction(G4String OutName,MyG4Args* MainArgs)
             man->CreateNtupleDColumn("fLDIQR");
             man->CreateNtupleDColumn("fLStIQR");
             man->FinishNtuple(5); // Finish our first tuple or Ntuple number 0
+
+	    //Tuple containing the digitized Sipm information at the end of each event.
+
+            man->CreateNtuple("Digi Collection","Digi Collection");
+            man->CreateNtupleDColumn("SipmID"); 
+            man->CreateNtupleDColumn("CellID"); 
+            man->CreateNtupleDColumn("TriggerType"); 
+            man->CreateNtupleDColumn("BreakdownTime");
+            man->CreateNtupleDColumn("CellGain");
+	    man->FinishNtuple(6);
         }
 }
 MyRunAction :: ~MyRunAction()


### PR DESCRIPTION
Finish implementing G4sipm. Use the -G4Sipm command to use the package. Only default sipms are used right now. Custom ones  can be easily defined. Voltage trace readout is not fully implemented, because I still need to talk to you and Kai about how we are storing the Voltage integration information. I updated the README to include install instructions for G4Sipm and the usage of -G4Sipm command. I made sure that every geom config that uses sensitive detectors can also use G4Sipms through the -G4Sipm command. There are some changes to the Makefile.localgmsh. You should go through them. They worked on my end but everyone's setup is a little different. Though I think it will also work for you.